### PR TITLE
Pin mode not being set at initialization

### DIFF
--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -65,14 +65,14 @@ class GPIO
   #
   # @param pin [Integer] GPIO pin number to use
   # @param mode [String] pin mode : IN or OUT
-  def initialize(pin, mode = OUT)
+  def initialize(pin, _mode = OUT)
     @pin = pin
 
     unexport_pin
     export_pin
-
-    @mode = mode
     @exported = true
+
+    self.mode = _mode
   end
 
   # Set the pin mode

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -95,7 +95,7 @@ class GPIO
   #
   # @return [Integer] pin's value : 0 or 1
   def value
-    File.open("#{LIB_PATH}/gpio#{@pin}/value", 'r').read
+    File.open("#{LIB_PATH}/gpio#{@pin}/value", 'r').read.to_i
   end
 
   # Set a value to the pin


### PR DESCRIPTION
I kept getting `Errno::EPERM (Operation not permitted @ fptr_finalize_flush - /sys/class/gpio/gpio4/value)` when attempting to set the value of a GPIO pin.  The output of `gpio readall` revealed that the output was still set as "IN", even though I was initializing the pin as `OUT`.

I found that if I add `pin.mode = OUT` before `pin.value = `, it worked.

Looking at the source, it seemed that the initializer was only setting the mode in an instance variable and never actually calling the setter.  I changed the initializer to call the setter, and now GPIO pins have the correct mode when initialized.